### PR TITLE
Svelte 4 #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [0.3.1](https://github.com/brandonp-ais/ag-grid-svelte/compare/v0.3.0-a...v0.3.1) (2023-09-04)
+
 ## [0.3.0](https://github.com/MichaelKim/ag-grid-svelte/compare/v0.2.1...v0.3.0) (2023-07-06)
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![NPM Version](https://img.shields.io/npm/v/ag-grid-svelte?color=40b3ff)](https://npmjs.org/package/ag-grid-svelte) [![license](https://img.shields.io/github/license/michaelkim/ag-grid-svelte)](LICENSE)
 
+NB: This is a temporary fork of ag-grid-svelte until that package updates to Svelte 4.
+
 An unofficial Svelte wrapper for [AG Grid](http://www.ag-grid.com/). Tested with v28 to v30.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "ag-grid-svelte",
-  "version": "0.3.0",
+  "version": "0.3.0-a",
   "description": "An unofficial Svelte wrapper for AG Grid",
   "type": "module",
   "devDependencies": {
     "@playwright/test": "^1.34.0",
     "@sveltejs/adapter-static": "^2.0.2",
-    "@sveltejs/kit": "^1.18.0",
+    "@sveltejs/kit": "^1.20.4",
     "@sveltejs/package": "^2.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
@@ -18,10 +18,10 @@
     "eslint-plugin-svelte3": "^4.0.0",
     "highlight.js": "^11.8.0",
     "prettier": "^2.8.8",
-    "prettier-plugin-svelte": "^2.10.0",
+    "prettier-plugin-svelte": "^2.10.1",
     "sass": "^1.62.1",
-    "svelte": "^3.55.0",
-    "svelte-check": "^3.3.2",
+    "svelte": "^4.0.0",
+    "svelte-check": "^3.4.3",
     "svelte-preprocess": "^5.0.3",
     "svelte2tsx": "^0.6.14",
     "tslib": "^2.5.2",
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "ag-grid-community": "^28 || ^29 || ^30",
-    "svelte": "^3"
+    "svelte": "^3 || ^4"
   },
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,70 +1,70 @@
 {
-  "name": "ag-grid-svelte",
-  "version": "0.3.0-a",
-  "description": "An unofficial Svelte wrapper for AG Grid",
-  "type": "module",
-  "devDependencies": {
-    "@playwright/test": "^1.34.0",
-    "@sveltejs/adapter-static": "^2.0.2",
-    "@sveltejs/kit": "^1.20.4",
-    "@sveltejs/package": "^2.0.2",
-    "@typescript-eslint/eslint-plugin": "^5.59.6",
-    "@typescript-eslint/parser": "^5.59.6",
-    "ag-grid-community": "^30.0.0",
-    "ag-grid-enterprise": "^30.0.0",
-    "commit-and-tag-version": "^11.2.1",
-    "eslint": "^8.41.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-svelte3": "^4.0.0",
-    "highlight.js": "^11.8.0",
-    "prettier": "^2.8.8",
-    "prettier-plugin-svelte": "^2.10.1",
-    "sass": "^1.62.1",
-    "svelte": "^4.0.0",
-    "svelte-check": "^3.4.3",
-    "svelte-preprocess": "^5.0.3",
-    "svelte2tsx": "^0.6.14",
-    "tslib": "^2.5.2",
-    "typescript": "^5.0.4",
-    "vite": "^4.3.8"
-  },
-  "peerDependencies": {
-    "ag-grid-community": "^28 || ^29 || ^30",
-    "svelte": "^3 || ^4"
-  },
-  "scripts": {
-    "dev": "vite dev",
-    "build": "vite build",
-    "package": "svelte-package",
-    "preview": "vite preview",
-    "test": "playwright test",
-    "check": "svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check --plugin-search-dir=. . && eslint .",
-    "format": "prettier --write --plugin-search-dir=. .",
-    "release": "commit-and-tag-version"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/MichaelKim/ag-grid-svelte.git"
-  },
-  "keywords": [],
-  "author": "Michael Kim",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/MichaelKim/ag-grid-svelte/issues"
-  },
-  "homepage": "https://github.com/MichaelKim/ag-grid-svelte#readme",
-  "files": [
-    "dist"
-  ],
-  "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "svelte": "./dist/index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
-    }
-  }
+	"name": "ag-grid-svelte",
+	"version": "0.3.0",
+	"description": "An unofficial Svelte wrapper for AG Grid",
+	"type": "module",
+	"devDependencies": {
+		"@playwright/test": "^1.34.0",
+		"@sveltejs/adapter-static": "^2.0.2",
+		"@sveltejs/kit": "^1.20.4",
+		"@sveltejs/package": "^2.0.2",
+		"@typescript-eslint/eslint-plugin": "^5.59.6",
+		"@typescript-eslint/parser": "^5.59.6",
+		"ag-grid-community": "^30.0.0",
+		"ag-grid-enterprise": "^30.0.0",
+		"commit-and-tag-version": "^11.2.1",
+		"eslint": "^8.41.0",
+		"eslint-config-prettier": "^8.8.0",
+		"eslint-plugin-svelte3": "^4.0.0",
+		"highlight.js": "^11.8.0",
+		"prettier": "^2.8.8",
+		"prettier-plugin-svelte": "^2.10.1",
+		"sass": "^1.62.1",
+		"svelte": "^4.0.0",
+		"svelte-check": "^3.4.3",
+		"svelte-preprocess": "^5.0.3",
+		"svelte2tsx": "^0.6.14",
+		"tslib": "^2.5.2",
+		"typescript": "^5.0.4",
+		"vite": "^4.3.8"
+	},
+	"peerDependencies": {
+		"ag-grid-community": "^28 || ^29 || ^30",
+		"svelte": "^3 || ^4"
+	},
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"package": "svelte-package",
+		"preview": "vite preview",
+		"test": "playwright test",
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
+		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
+		"format": "prettier --write --plugin-search-dir=. .",
+		"release": "commit-and-tag-version"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/brandonp-ais/ag-grid-svelte.git"
+	},
+	"keywords": [],
+	"author": "Michael Kim",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/brandonp-ais/ag-grid-svelte/issues"
+	},
+	"homepage": "https://github.com/brandonp-ais/ag-grid-svelte#readme",
+	"files": [
+		"dist"
+	],
+	"types": "./dist/index.d.ts",
+	"main": "./dist/index.js",
+	"svelte": "./dist/index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ag-grid-svelte",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "An unofficial Svelte wrapper for AG Grid",
 	"type": "module",
 	"devDependencies": {

--- a/src/components/NavBar.svelte
+++ b/src/components/NavBar.svelte
@@ -26,9 +26,9 @@
     class="backdrop"
     on:click={() => (open = false)}
     aria-hidden="true"
-    transition:fade={{ duration: 150 }}
+    transition:fade|global={{ duration: 150 }}
   />
-  <div class="nav-bar" transition:fly={{ x: -200, duration: 200 }}>
+  <div class="nav-bar" transition:fly|global={{ x: -200, duration: 200 }}>
     <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div tabindex="0" bind:this={start} />
     <Logo />

--- a/src/lib/SvelteFrameworkComponentWrapper.ts
+++ b/src/lib/SvelteFrameworkComponentWrapper.ts
@@ -5,7 +5,7 @@ import {
   type IComponent,
   type WrappableInterface
 } from 'ag-grid-community';
-import type { ComponentType as SvelteComponentType, SvelteComponentTyped } from 'svelte';
+import type { ComponentType as SvelteComponentType, SvelteComponent } from 'svelte';
 import { SvelteComponent } from 'svelte/internal';
 
 // Called when a Svelte component is provided to override a default grid component
@@ -20,7 +20,7 @@ export class SvelteFrameworkComponentWrapper
 
 class NewSvelteComponent<P> implements IComponent<P>, WrappableInterface {
   private eParentElement!: HTMLElement;
-  private componentInstance!: SvelteComponentTyped<{ params: P }>;
+  private componentInstance!: SvelteComponent<{ params: P }>;
   private methods: { [name: string]: (...args: P[]) => void } = {
     // Provide a default refresh method
     refresh: (params: P) => {
@@ -29,7 +29,7 @@ class NewSvelteComponent<P> implements IComponent<P>, WrappableInterface {
     }
   };
 
-  constructor(private SvelteComponent: SvelteComponentType<SvelteComponentTyped<{ params: P }>>) {}
+  constructor(private SvelteComponent: SvelteComponentType<SvelteComponent<{ params: P }>>) {}
 
   init(params: P): void {
     // Guaranteed to be called


### PR DESCRIPTION
Updates project and peerDependencies to Svelte 4.

Migration done by running `npx svelte-migrate@latest svelte-4` from svelte migration document linked in issue.